### PR TITLE
Improved documentation

### DIFF
--- a/guides/integration/mobile-sdk.html.md
+++ b/guides/integration/mobile-sdk.html.md
@@ -61,6 +61,7 @@ For details how to integrate the SDK with a particular IDE or build system and O
 <div class="tab-content">
   <div class="tab-pane active" id="integration-ios">
     <ul>
+      <li>Tested with iOS versions 6 to 8.3</li>
       <li><a href="https://github.com/paymill/paymill-ios/releases">SDK</a></li>
       <li><a href="https://github.com/paymill/paymill-ios/tree/master/samples/vouchermill">Sample App</a></li>
       <li><a href="https://github.com/paymill/paymill-example-ios-parse-honeystore">App integration HowTo</a></li>
@@ -70,6 +71,7 @@ For details how to integrate the SDK with a particular IDE or build system and O
 
   <div class="tab-pane" id="integration-android">
     <ul>
+      <li>Tested with Android versions 2.2 (API 8) to 4.2</li>
       <li><a href="https://github.com/paymill/paymill-android/releases">SDK</a></li>
       <li><a href="https://github.com/paymill/paymill-android/tree/master/samples/vouchermill">Sample App</a></li>
       <li><a href="http://paymill.github.io/paymill-android/docs/sdk/">Documentation</a></li>

--- a/guides/reference/bridge-payframe-migration.html.md
+++ b/guides/reference/bridge-payframe-migration.html.md
@@ -62,7 +62,7 @@ For the purpose of this guide, let's assume the integration on your site looks s
 
   // Submit handler for payment form.
   var form = $('#payment-form');
-  form.submit(function(event) {
+  form.on('submit', function(event) {
 
     // Don't submit the form yet.
     event.preventDefault();
@@ -81,9 +81,9 @@ For the purpose of this guide, let's assume the integration on your site looks s
         // Token could not be created, handle error.
         console.log(error.apierror, error.message);
       } else {
-        // Attach token to form and submit it.
+        // Attach token to form, remove event handler and submit form.
         form.find('.token').val(result.token);
-        form.submit();
+        form.off('submit').submit();
       }
     });
 
@@ -172,9 +172,9 @@ paymill.createTokenViaFrame({
     // Token could not be created, handle error.
     console.log(error.apierror);
   } else {
-    // Attach token to form and submit it.
+    // Attach token to form, remove event handler and submit form.
     form.find('.token').val(result.token);
-    form.submit();
+    form.off('submit').submit();
   }
 });
 ```
@@ -231,7 +231,7 @@ After having made the changes described above, your integration should now look 
 
   // Submit handler for payment form.
   var form = $('#payment-form');
-  form.submit(function(event) {
+  form.on('submit', function(event) {
 
     // Don't submit the form yet.
     event.preventDefault();
@@ -246,7 +246,7 @@ After having made the changes described above, your integration should now look 
       } else {
         // Attach token to form and submit it.
         form.find('.token').val(result.token);
-        form.submit();
+        form.off('submit').submit();
       }
     });
 


### PR DESCRIPTION
The way the payment form is submitted in the PayFrame migration guide has been fixed, the previous method resulted in an endless loop because the `submit` listener wasn’t removed.

Mobile SDK documentation now includes information about which OS versions the SDK has been tested with.
