### PR TITLE
Document item amount correctly

### DIFF
--- a/API/O-internal_objects.html.md.eco
+++ b/API/O-internal_objects.html.md.eco
@@ -230,8 +230,9 @@ Item name, *max. 127 characters*
 ***description:*** _string_  
 Additional description, *max. 127 characters*
 
-**amount:** _integer (> 0)_  
-Price for a single item, including tax, can also be *negative* to act as a discount
+**amount:** _integer_  
+Price for a single item (including tax)  
+Can be positive, zero, or negative (to represent a discount)
 
 **quantity:** _integer (> 0)_  
 Quantity of this item


### PR DESCRIPTION
Shopping cart items can now have an amount that is _zero_ (if item is just there for information) or _negative_ (e.g. to represent a discount).
