### PR TITLE
How to request a shipping address

### DIFF
--- a/API/J-checksums.html.md.eco
+++ b/API/J-checksums.html.md.eco
@@ -84,3 +84,20 @@ The identifier of the payment from which the fee will be charged ([creditcard-ob
 
 **fee_currency:** _string or unset_  
 The currency of the fee (e.g. EUR, USD). If it´s not set, the currency of the transaction is used. We suggest to always use as it might cause problems, if your account does not support the same currencies as your merchants accounts.
+
+**checkout_options:** _[checkout options](#checkout-options) or null_  
+Various options that determine behavior before/during/after checkout such as editability of address fields.
+
+## Checkout Options
+
+Checkout options determine how PAYMILL's system and/or the acquirer's system (e.g. PayPal) should behave before, during and after checkout.
+
+For example, you can specify whether or not the buyer can provide or edit the address fields of a transaction.
+
+### Attributes
+
+### Attributes
+
+**shipping_address_editable:** _boolean or null_  
+Whether or not the shipping address can be edited by the buyer.  
+If set to `true`, buyer can change the specified address or provide one themselves if none is specified.

--- a/guides/reference/address-data.html.md
+++ b/guides/reference/address-data.html.md
@@ -99,10 +99,62 @@ For PayPal transactions, the field "state" is mandatory in several countries. Pl
 </div>
 
 ### Requesting a shipping address
-**This feature will be available soon.**
 
-PayPal Express Checkout Shortcut (ECS) allows your to obtain an address via PayPal. Instead of providing an address yourself, simply specify that you need one.
+PayPal Express Checkout Shortcut (ECS) allows your to obtain an address via PayPal. Instead of providing an address yourself, simply specify that you need one. You can also provide a shipping address and allow the buyer to change it during checkout.
+
+To allow the buyer to either provide or change the shipping address, simply set `shipping_address_editable` when setting up a checkout (it's set to `false` by default). Options like this are specified inside the `checkout_options` of a checksum.
 
 <div class="info">
-For the time being, if no shipping address is provided the customer will be prevented from entering one during PayPal checkout.
+Technically you don't have to provide a shipping address, but PayPal seller protection might require you to do so. When selling physical products, we recommend to always provide or collect a shipping address.
+</div>
+
+Overall, there are four different cases to keep in mind:
+
+- If you provide a shipping address:
+  - If you don't set `shipping_address_editable` or set it to `false`, the buyer won't be able to change the address.
+  - If you set `shipping_address_editable=true`, the buyer will be able to change the address (but doesn't have to).
+- If you don't provide a shipping address:
+  - If you don't set `shipping_address_editable` or set it to `false`, the buyer won't be able to provide an address.
+  - If you set `shipping_address_editable=true`, the buyer will be able to provide an address (but doesn't have to).
+
+Example for how to let the buyer provide a shipping address:
+
+```sh
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "amount=4200" \
+  -d "currency=EUR" \
+  -d "description=Test Transaction" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry" \
+  -d "checkout_options[shipping_address_editable]=true"
+```
+
+Example for how to provide a shipping address but let the buyer change it if they want to:
+
+```sh
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "amount=4200" \
+  -d "currency=EUR" \
+  -d "description=Test Transaction" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry" \
+  -d "shipping_address[name]=Max Mustermann" \
+  -d "shipping_address[street_address]": "Musterstr. 1", \
+  -d "shipping_address[street_address_addition]": "", \
+  -d "shipping_address[city]": "Munich", \
+  -d "shipping_address[state]": "Bavaria", \
+  -d "shipping_address[postal_code]": "80333", \
+  -d "shipping_address[country]": "DE", \
+  -d "shipping_address[phone]": "+4989123456" \
+  -d "checkout_options[shipping_address_editable]=true"
+```
+
+After successful checkout, your transaction will be updated with the shipping address obtained from PayPal. Simply retrieve [transaction details](/API/#-transaction-details) from our API to get the provided or changed shipping address.
+
+<div class="important">
+If you make the shipping address editable, regardless of whether you provide one yourself or not, you should always retrieve the updated transaction after checkout to avoid using the wrong address.
 </div>

--- a/guides/reference/transactions.html.md
+++ b/guides/reference/transactions.html.md
@@ -187,7 +187,7 @@ curl https://api.paymill.com/v2.1/checksums \
   -d "description=Test Transaction"
 ```
 
-You can add any type of transaction data to the checksum, this includes shipping/handling costs, shopping cart items, shipping/billing address as well as return/cancel URLs for PayPal.
+You can add any type of transaction data to the checksum, this includes shipping/handling costs, shopping cart items, shipping/billing address as well as return/cancel URLs for PayPal. See our guides on [address data](/guides/reference/address-data.html) and [shopping cart data](/guides/reference/shopping-cart.html) as well as [PayPal transactions](/guides/paypal/transactions.html) for more information.
 
 Here's an example of a checksum for a full-fledged transaction:
 


### PR DESCRIPTION
Merchants can now either request a shipping address from their customers or allow that the provided shipping address can be changed using the new `shipping_address_editable` flag.
