### PR TITLE
PayPal recurring payments

### DIFF
--- a/API/C-response_codes.html.md.eco
+++ b/API/C-response_codes.html.md.eco
@@ -89,14 +89,18 @@ These codes are 5-digit numbers whereas the first digit indicates whether the re
 - `50410`: Personal Account Protection (PAP)
 - `50420`: Rejected due to acquirer fraud settings
 - `50430`: Rejected due to acquirer risk settings
-- `50440`: Failed due to PayPal account restrictions
+- `50440`: Failed due to restrictions with acquirer account
+- `50450`: Failed due to restrictions with user account
 - `50500`: General timeout
 - `50501`: Timeout on side of the acquirer
 - `50502`: Risk management transaction timeout
-- `50600`: Duplicate transaction
+- `50600`: Duplicate operation
 - `50700`: Cancelled by user
 - `50710`: Failed due to funding source
 - `50711`: Payment method not usable, use other payment method
+- `50712`: Limit of funding source was exceeded
+- `50713`: Means of payment not reusable (canceled by user)
+- `50714`: Means of payment not reusable (expired)
 - `50720`: Rejected by acquirer
 - `50730`: Transaction denied by merchant
 - `50800`: Preauthorisation failed

--- a/API/J-checksums.html.md.eco
+++ b/API/J-checksums.html.md.eco
@@ -78,7 +78,7 @@ Shipping address for this transaction.
 **billing_address:** _[address object](#address-object) or null_  
 Billing address for this transaction.
 
-**client_id:** _string or null_  
+**client:** _string or null_  
 Client (ID) where the created payment should belong to.
 
 **app_id:** _string or null_  
@@ -116,7 +116,7 @@ curl https://api.paymill.com/v2.1/checksums \
   -d "checksum_action=payment" \
   -d "return_url=https://www.example.com/store/checkout/result" \
   -d "cancel_url=https://www.example.com/store/checkout/retry" \
-  -d "client_id=client_7b7ebc8d0770bc3f7c2e"
+  -d "client=client_7b7ebc8d0770bc3f7c2e"
 ```
 
 > Response
@@ -126,7 +126,7 @@ curl https://api.paymill.com/v2.1/checksums \
   "data": {
     "id": "chk_3902f931f57d6ddb0088bc1e2f94",
     "checksum": "a4a67b151b9a8c2403cb153fa9628cd7213dbd67a1834ceee7ce03dd651b4db6ad8c07764b1fe6175a9f514aa9bd23b8a982875a8f86fb063dc7c199e75b9332",
-    "data": "return_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fresult&cancel_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fretry&client_id=client_7b7ebc8d0770bc3f7c2e",
+    "data": "return_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fresult&cancel_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fretry&client=client_7b7ebc8d0770bc3f7c2e",
     "type": "paypal",
     "action": "payment",
     "app_id": null,
@@ -156,8 +156,8 @@ URL to redirect customers to after checkout has completed. Transaction status wi
 URL to redirect customers to after they have canceled the checkout. As a result, there will be no transaction.  
 **Mandatory for client-side transactions, e.g. PayPal**
 
-**client_id:** _string or null_  
-Client (ID) where the created payment should belong to.
+**client:** _string or null_  
+Client (ID) that the created payment should belong to.
 
 **app_id:** _string or null_  
 App (ID) that created this payment or null if created by yourself.

--- a/API/J-checksums.html.md.eco
+++ b/API/J-checksums.html.md.eco
@@ -98,6 +98,13 @@ The currency of the fee (e.g. EUR, USD). If it´s not set, the currency of the t
 **checkout_options:** _[checkout options](#checkout-options) or null_  
 Various options that determine behavior before/during/after checkout such as editability of address fields.
 
+**require_reusable_payment:** _boolean or null_  
+Set this to `true` if you want to ask the buyer for a billing agreement during checkout.  
+If the buyer accepts, the resulting payment can be reused for transactions and subscriptions without additional interaction.
+
+**reusable_payment_description:** _string or null_  
+Description appears at the acquirers checkout page (e.g. PayPal) when you request permission for a reusable payment, *max. 127 characters*
+
 ## Create new payment checksum
 
 > Request
@@ -155,13 +162,14 @@ Client (ID) where the created payment should belong to.
 **app_id:** _string or null_  
 App (ID) that created this payment or null if created by yourself.
 
+**reusable_payment_description:** _string or null_  
+Description appears at the acquirers checkout page (e.g. PayPal) when you request permission for a reusable payment.
+
 ## Checkout Options
 
 Checkout options determine how PAYMILL's system and/or the acquirer's system (e.g. PayPal) should behave before, during and after checkout.
 
 For example, you can specify whether or not the buyer can provide or edit the address fields of a transaction.
-
-### Attributes
 
 ### Attributes
 

--- a/API/J-checksums.html.md.eco
+++ b/API/J-checksums.html.md.eco
@@ -8,7 +8,7 @@ Checksum validation is a simple method to ensure the integrity of transferred da
 
 For transactions that are started client-side, e.g. PayPal checkout, it is *required* to first create a checksum on your server and then provide that checksum when starting the transaction in the browser. The checksum needs to contain *all* data required to subsequently create the actual transaction.
 
-## Create new Checksum
+## Create new transaction checksum
 
 > Request
 
@@ -27,13 +27,17 @@ curl https://api.paymill.com/v2.1/checksums \
 
 ```json
 {
+  "data": {
     "id":"chk_9fc0af0f6107706e4a4b8d7e71b5",
     "checksum":"edc26c087697a277230539da0e89b1ab96b93bc635e980c78573de6be3041689c77401bc299aa8c98cda33abe6b097f3df009feb495b19215f407c9655401c1b",
     "data":"amount=4200&currency=EUR&description=Test+Transaction&return_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fresult&cancel_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fretry",
     "type":"paypal",
+    "action": "transaction",
     "app_id":null,
-    "created_at":1433248940,
-    "updated_at":1433248940
+    "created_at": 1438176779,
+    "updated_at": 1438176779
+  },
+  "mode": "test"
 }
 ```
 
@@ -44,6 +48,9 @@ ID of this checksum
 
 **checksum_type:** _enum(paypal)_  
 Type of request verified by this checksum
+
+**checksum_action:** _enum(transaction, payment)_ or null_
+Requested action verified by this checksum (default: transaction)
 
 **amount:** _ string_  
 Formatted amount of this transaction.
@@ -71,6 +78,9 @@ Shipping address for this transaction.
 **billing_address:** _[address object](#address-object) or null_  
 Billing address for this transaction.
 
+**client_id:** _string or null_  
+Client (ID) where the created payment should belong to.
+
 **app_id:** _string or null_  
 App (ID) that created this refund or null if created by yourself.
 
@@ -87,6 +97,63 @@ The currency of the fee (e.g. EUR, USD). If it´s not set, the currency of the t
 
 **checkout_options:** _[checkout options](#checkout-options) or null_  
 Various options that determine behavior before/during/after checkout such as editability of address fields.
+
+## Create new payment checksum
+
+> Request
+
+```bash
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "checksum_action=payment" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry" \
+  -d "client_id=client_7b7ebc8d0770bc3f7c2e"
+```
+
+> Response
+
+```json
+{
+  "data": {
+    "id": "chk_3902f931f57d6ddb0088bc1e2f94",
+    "checksum": "a4a67b151b9a8c2403cb153fa9628cd7213dbd67a1834ceee7ce03dd651b4db6ad8c07764b1fe6175a9f514aa9bd23b8a982875a8f86fb063dc7c199e75b9332",
+    "data": "return_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fresult&cancel_url=https%3A%2F%2Fwww.example.com%2Fstore%2Fcheckout%2Fretry&client_id=client_7b7ebc8d0770bc3f7c2e",
+    "type": "paypal",
+    "action": "payment",
+    "app_id": null,
+    "created_at": 1438176779,
+    "updated_at": 1438176779
+  },
+  "mode": "test"
+}
+```
+
+### Attributes
+
+**id:** _string_  
+ID of this checksum
+
+**checksum_type:** _enum(paypal)_  
+Type of request verified by this checksum
+
+**checksum_action:** _enum(transaction, payment)_ or null_
+Requested action verified by this checksum (default: transaction)
+
+**return_url:** _string_
+URL to redirect customers to after checkout has completed. Transaction status will be closed, failed or pending.  
+**Mandatory for client-side transactions, e.g. PayPal**
+
+**cancel_url:** _string_  
+URL to redirect customers to after they have canceled the checkout. As a result, there will be no transaction.  
+**Mandatory for client-side transactions, e.g. PayPal**
+
+**client_id:** _string or null_  
+Client (ID) where the created payment should belong to.
+
+**app_id:** _string or null_  
+App (ID) that created this payment or null if created by yourself.
 
 ## Checkout Options
 

--- a/API/M-subscriptions.html.md.eco
+++ b/API/M-subscriptions.html.md.eco
@@ -4,7 +4,7 @@ anchor: "subscriptions"
 type: "apiDoc"
 ---
 
-Subscriptions allow you to charge recurring payments on a client's credit card / to a client's direct debit. A subscription connects a client to the [offers-object](#-offer-object). A client can have several subscriptions to different offers, but only one subscription to the same offer.
+Subscriptions allow you to charge recurring payments on a client's credit card / direct debit account / PayPal account. A subscription connects a client to the [offers-object](#-offer-object). A client can have several subscriptions to different offers, but only one subscription to the same offer.
 
 ## `Subscription` object
 
@@ -42,7 +42,7 @@ Subscriptions allow you to charge recurring payments on a client's credit card /
 
 <pre>
   subscription.offer returns an <a href="#-offer-object">offer object</a>
-  subscription.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  subscription.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   subscription.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -96,13 +96,13 @@ Unix-Timestamp for the last update
 **canceled_at:**           _integer / null_  
 Unix-Timestamp for the cancel date
 
-**payment:**               _[payment object for credit card](#-payment-object-for-credit-card-payments) / [payment object for direct debit](#-payment-object-for-direct-debit-payments)_  
-payment object for credit card or payment object for direct debit
+**payment:**               _[payment object for credit card](#-payment-object-for-credit-card-payments) / [payment object for direct debit](#-payment-object-for-direct-debit-payments) / [payment object for PayPal](#-payment-object-for-paypal-payments)_ 
+payment object for credit card, direct debit or PayPal
 
 **mandate_reference:**     _string or null_  
 SEPA mandate reference, can be optionally specified for direct debit transactions. If specified for other payment methods, it has no effect but must still be valid. If specified, the string must not be empty, can be up to 35 characters long and may contain digits 0-9, letters a-z A-Z, allowed special characters: ‘ , . : + - / ( ) ?
 
-**client:**                _[client object](#-client-object)  
+**client:**                _[client object](#-client-object)  _
 client object
 
 **app_id:**                _string / null_
@@ -339,7 +339,7 @@ curl https://api.paymill.com/v2.1/subscriptions \
 
 <pre>
   - <a href="#-subscriptions-object">subscription</a>.offer returns an <a href="#-offer-object">offer object</a>
-  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   - <a href="#-subscriptions-object">subscription</a>.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -447,7 +447,7 @@ curl https://api.paymill.com/v2.1/subscriptions/sub_dc180b755d10da324864 \
 
 <pre>
   - <a href="#-subscriptions-object">subscription</a>.offer returns an <a href="#-offer-object">offer object</a>
-  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   - <a href="#-subscriptions-object">subscription</a>.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -741,7 +741,7 @@ curl https://api.paymill.com/v2.1/subscriptions/sub_dea86e5c65b2087202e3 \
 
 <pre>
   - <a href="#-subscriptions-object">subscription</a>.offer returns an <a href="#-offer-object">offer object</a>
-  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   - <a href="#-subscriptions-object">subscription</a>.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -928,7 +928,7 @@ curl https://api.paymill.com/v2.1/subscriptions/sub_d68bcdc8656a7932eb44 \
 
 <pre>
   - <a href="#-subscriptions-object">subscription</a>.offer returns an <a href="#-offer-object">offer object</a>
-  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   - <a href="#-subscriptions-object">subscription</a>.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -1009,7 +1009,7 @@ curl https://api.paymill.com/v2.1/subscriptions \
 
 <pre>
   - <a href="#-subscriptions-object">subscription</a>.offer returns an <a href="#-offer-object">offer object</a>
-  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a> or a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a>
+  - <a href="#-subscriptions-object">subscription</a>.payment returns a <a href="#-payment-object-for-credit-card-payments">payment object for credit card</a>, a <a href="#-payment-object-for-direct-debit-payments">payment object for direct debit</a> or a <a href="#-payment-object-for-paypal-payments">payment object for PayPal</a>
   - <a href="#-subscriptions-object">subscription</a>.client returns a <a href="#-client-object">client object</a>
 </pre>
 
@@ -1025,7 +1025,13 @@ This function returns a JSON object with a list of subscriptions. In which order
 Available [filters](#filter-entries):
 
   - `offer=<offer id>`
+  - `currency=<string> ISO 4217 formatted currency code`
   - `created_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `updated_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `canceled_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `payment_type=creditcard|debit|paypal`
+  - `is_deleted=1|0`
+  - `mandate_reference=<string>`
 
 ## Export `Subscriptions` List
 
@@ -1075,8 +1081,11 @@ This function returns CSV separated by semicolons, encapsulated by double quotes
 
 Available [filters](#filter-entries):
 
-  - offer
-  - currency
-  - created_at
-  - canceled_at
-  - updated_at
+  - `offer=<offer id>`
+  - `currency=<string> ISO 4217 formatted currency code`
+  - `created_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `updated_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `canceled_at=<timestamp> | <timestamp (from)>-<timestamp (to)>`
+  - `payment_type=creditcard|debit|paypal`
+  - `is_deleted=1|0`
+  - `mandate_reference=<string>`

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -1,0 +1,104 @@
+---
+title: "PayPal Payments"
+menu: "PayPal Payments"
+type: "guide"
+status: "published"
+menuOrder: 4
+---
+
+Requesting PayPal billing agreements through PAYMILL is easy:
+
+1. Add a "Pay with PayPal" button to your checkout (use images from the [PayPal logo center](https://www.paypal.com/webapps/mpp/logo-center)).
+- Safely prepare the request on your server by creating a PayPal payment checksum.
+- Pass the checksum ID to your website front-end and use our bridge to start PayPal checkout.
+- Handle the customer returning to your site along with information about the transaction result.
+
+## Payment setup
+
+Before you can start the PayPal checkout from your website, you need to create a payment checksum on your server using your private API key. This is to ensure the integrity of the payment data and to prevent your payment from being tampered with along the way.
+
+You need to define a return and cancel URL for PayPal. Optionally you can also add a client ID if you want to assign the new payment to an existing client.
+
+<div class="info">
+Please refer to our [API reference](/API) for more information on payment details.
+</div>
+
+### Mandatory payment details
+
+A PayPal payment needs the checksum type and action to be specified. You also need to provide a valid cancel URL and return URL for the customer to return to.
+
+- **checksum_type:** Needs to be set to "paypal".
+- **checksum_action:** Needs to be set to "payment" so that the checksum is later turned into a PayPal payment.
+- **return_url:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
+- **cancel_url:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
+
+This example checksum contains all mandatory information for a PayPal transaction:
+
+```sh
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "checksum_action=payment" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry"
+```
+
+### Optional payment details
+
+In addition to the mandatory payment details listed above, you can specify several other components of a payment:
+
+- **client_id:** Client (ID) where the created payment should belong to (optional).
+
+Please see our guide on [transactions](/guides/reference/payments.html) for more details on payment setup.
+
+## PayPal checkout
+
+PayPal payments are initiated on your website. The customer is redirected to PayPal checkout and subsequently returned to your site where you can handle the result.
+
+1. Include the PAYMILL JavaScript bridge.
+- When button is clicked, use our JS bridge to start PayPal checkout.
+- Provide callback to handle any errors during payment setup (e.g. invalid data)
+
+```javascript
+paymill.createPayment({
+  checksum: 'chk_2f82a672574647cd911d'
+}, function(error) {
+  if (error) {
+    // Payment setup failed, handle error and try again.
+    console.log(error);
+  }
+});
+```
+
+## Cancelled payments
+
+When a customer cancels during PayPal checkout, they will be redirected to your **cancel URL**. This is a separate URL so you can offer your customers to review or modify their order and restart the checkout.
+
+Since no payment was created at this point, the customer is simply redirected to your cancel URL without any additional parameters.
+
+Here's an example URL called for a cancelled payment:
+
+```sh
+https://www.example.com/shop/checkout/retry
+```
+
+## Payment results
+
+After PayPal checkout, the customer is redirected to your **return URL**. At this point, a payment has been created. The payment result is provided using the following URL parameters:
+
+- `paymill_payment_id`: PAYMILL payment ID, used to identify the payment in PAYMILL's system
+
+Here's an example URL called for a successful transaction:
+
+```sh
+https://www.example.com/shop/checkout/result?paymill_payment_id=pay_2af32f858a47babeff78aeef
+```
+
+### Retrieving payment details
+
+After a payment has created, you can retrieve additional payment details from our API, such as the country of the customer:
+
+```sh
+curl https://api.paymill.com/v2.1/payments/pay_2af32f858a47babeff78aeef \
+  -u "<YOUR_PRIVATE_KEY>:"
+```

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -6,18 +6,62 @@ status: "published"
 menuOrder: 4
 ---
 
-Requesting PayPal billing agreements through PAYMILL is easy:
+A PayPal payment object represents the customer's PayPal account. When carrying out a PayPal transaction, a payment object is automatically created for the PayPal account used to pay. You can attach the payment to an existing client by specifying the client ID when creating a transaction or payment, otherwise a new client will be created automatically. See our guide on [clients and payments](/guides/reference/clients-payments.html) for more details on these relationships.
 
-1. Add a "Pay with PayPal" button to your checkout (use images from the [PayPal logo center](https://www.paypal.com/webapps/mpp/logo-center)).
-- Safely prepare the request on your server by creating a PayPal payment checksum.
-- Pass the checksum ID to your website front-end and use our bridge to start PayPal checkout.
-- Handle the customer returning to your site along with information about the transaction result.
+<div class="info">
+One client can have the same PayPal account attached to it multiple times. This is relevant when you create so-called *billing agreements* (see below), because you can have multiple different billing agreements with the same PayPal account.
+</div>
 
-## Payment setup
+## Reusing a PayPal payment object
 
-Before you can start the PayPal checkout from your website, you need to create a payment checksum on your server using your private API key. This is to ensure the integrity of the payment data and to prevent your payment from being tampered with along the way.
+You can normally use an existing payment object to create transactions and subscriptions. With PayPal, there is usually customer interaction involved.
 
-You need to define a return and cancel URL for PayPal. Optionally you can also add a client ID if you want to assign the new payment to an existing client.
+In order for a PayPal payment object to be reusable you have to obtain a so-called *billing agreement* from your customer. This allows you to charge future payments to their PayPal account and is indicated by `is_recurring=true` in the API response.
+
+Requesting PayPal billing agreements through PAYMILL is easy and can be done either while carrying out a transaction (see [transaction setup](/guides/paypal/transactions#transaction-setup)) or by setting up a special kind of checkout that *only creates a payment object*.
+
+To create a reusable payment **during** a transaction:
+
+1. Prepare the checkout by creating a checksum for a PayPal *transaction* on your server.
+- Set a flag to request a billing agreement during checkout, optionally add a description for why you need it.
+- Pass the checkout ID to your front-end and start the checkout using our JavaScript bridge.
+- When the customer returns, a `paymill_payment_id` will be attached identifying the reusable payment object.
+
+To create a reusable payment **without** a transaction:
+
+1. Prepare the checkout by creating a checksum for a PayPal *payment* on your server.
+- Optionally add a description for why you need the billing agreement.
+- Pass the checkout ID to your front-end and start the checkout using our JavaScript bridge.
+- When the customer returns, a `paymill_payment_id` will be attached identifying the reusable payment object.
+
+## Requesting a billing agreement during a transaction
+
+When creating a checksum for a PayPal *transaction*, simply set `require_reusable_payment=true` to request a billing agreement from your customer during checkout. Your customer will be able to authorize this payment and agree to future payments with a single click.
+
+Optionally, specify `reusable_payment_description` to let the customer know why exactly you need them to agree to future payments. This description will be displayed during checkout and will be added to every subsequent transaction based on this billing agreement.
+
+```sh
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "amount=4200" \
+  -d "currency=EUR" \
+  -d "description=Test Transaction" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry" \
+  -d "require_reusable_payment=true" \
+  -d "reusable_payment_description=Automatically pay invoices using this account."
+```
+
+<div class="info">
+Please see our [PayPal transaction guide](/guides/paypal/transactions.html) for more information on transaction setup. To learn more about creating a payment *without* a transaction, simply read on.
+</div>
+
+## Setting up a PayPal payment checkout
+
+To obtain a PayPal billing agreement without carrying out a transaction yet, you can set up a different type of checksum on your server. Simply specify `checksum_type=paypal` and `checksum_action=payment` to indicate that it's a PayPal checkout but a payment should be created instead of a transaction (which is the default action).
+
+Apart from the checksum type and action, you only need to define a return and cancel URL for PayPal. Optionally you can also add a description for why you need the billing agreement and specify a client ID if you want to assign the new payment to an existing client.
 
 <div class="info">
 Please refer to our [API reference](/API) for more information on payment details.
@@ -27,10 +71,10 @@ Please refer to our [API reference](/API) for more information on payment detail
 
 A PayPal payment needs the checksum type and action to be specified. You also need to provide a valid cancel URL and return URL for the customer to return to.
 
-- **checksum_type:** Needs to be set to "paypal".
-- **checksum_action:** Needs to be set to "payment" so that the checksum is later turned into a PayPal payment.
-- **return_url:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
-- **cancel_url:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
+- **Checksum type:** Needs to be set to `paypal`.
+- **Checksum action:** Needs to be set to `payment` so that the checksum is later turned into a PayPal payment. (`transaction` is the default value.)
+- **Return URL:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
+- **Cancel URL:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
 
 This example checksum contains all mandatory information for a PayPal transaction:
 
@@ -47,14 +91,27 @@ curl https://api.paymill.com/v2.1/checksums \
 
 In addition to the mandatory payment details listed above, you can specify several other components of a payment:
 
-- **client_id:** Client (ID) where the created payment should belong to (optional).
-- **reusable_payment_description:** The Description appears at the checkout page (max. 127 characters).
+- **Client ID:** Client (ID) where the created payment should belong to (optional).
+- **Reusable payment description:** The Description appears at the checkout page (max. 127 characters).
 
-Please see our guide on [payments](/guides/reference/payments.html) for more details on payment setup.
+```sh
+curl https://api.paymill.com/v2.1/checksums \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "checksum_type=paypal" \
+  -d "checksum_action=payment" \
+  -d "return_url=https://www.example.com/store/checkout/result" \
+  -d "cancel_url=https://www.example.com/store/checkout/retry" \
+  -d "client_id=client_b66a45c43fa384f2d45382e355f99"
+  -d "reusable_payment_description=Automatically pay invoices using this account."
+```
 
-## PayPal checkout
+<div class="info">
+Please see our guide on [clients and payments](/guides/reference/clients-payments.html) for more details on payment setup.
+</div>
 
-PayPal payments are initiated on your website. The customer is redirected to PayPal checkout and subsequently returned to your site where you can handle the result.
+## Starting a PayPal payment checkout
+
+Checkouts to create PayPal payments are initiated on your website, just like checkouts for transactions. The customer is redirected to PayPal checkout and subsequently returned to your site where you can handle the result.
 
 1. Include the PAYMILL JavaScript bridge.
 - When button is clicked, use our JS bridge to start PayPal checkout.
@@ -71,7 +128,7 @@ paymill.createPayment({
 });
 ```
 
-## Cancelled payments
+## Handling cancelled payments
 
 When a customer cancels during PayPal checkout, they will be redirected to your **cancel URL**. This is a separate URL so you can offer your customers to review or modify their order and restart the checkout.
 
@@ -83,7 +140,7 @@ Here's an example URL called for a cancelled payment:
 https://www.example.com/shop/checkout/retry
 ```
 
-## Payment results
+## Handling payment results
 
 After PayPal checkout, the customer is redirected to your **return URL**. At this point, a payment has been created. The payment result is provided using the following URL parameters:
 
@@ -106,6 +163,6 @@ curl https://api.paymill.com/v2.1/payments/pay_2af32f858a47babeff78aeef \
   -u "<YOUR_PRIVATE_KEY>:"
 ```
 
-<div class="info">If the payment attribute `is_recurring` is `true`, you can reuse it for creating transactions or subscriptions.<br>
-See [Create new Transaction with payment](/API/#-transaction-object) and [Create new Subscription](/API/#-subscription-object) for furhter information.
+<div class="info">
+If the payment attribute `is_recurring` is `true`, you can reuse it for to create a subsequent **transaction** or **subscription**, either via our API or Merchant Centre. See our [transaction guide](/guides/reference/transactions.html) and [subscription guide](/guides/reference/subscriptions.html) for more information
 </div>

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -87,10 +87,10 @@ https://www.example.com/shop/checkout/retry
 
 After PayPal checkout, the customer is redirected to your **return URL**. At this point, a payment has been created. The payment result is provided using the following URL parameters:
 
-- `paymill_payment_id`: PAYMILL payment ID, used to identify the payment in PAYMILL's system
-- `paymill_response_code`: Response code providing more details about the transaction status
+- `paymill_payment_id`: PAYMILL payment ID, used to identify the payment in PAYMILL's system.
+- `paymill_response_code`: Response code providing more details about the transaction status.
 - `paymill_mode`: Indicates if the transaction was made in `live` or `test` mode.
-- 
+
 Here's an example URL called for a successful transaction:
 
 ```sh

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -105,3 +105,7 @@ After a payment has created, you can retrieve additional payment details from ou
 curl https://api.paymill.com/v2.1/payments/pay_2af32f858a47babeff78aeef \
   -u "<YOUR_PRIVATE_KEY>:"
 ```
+
+<div class="info">If the payment attribute `is_recurring` is `true`, you can reuse it for creating transactions or subscriptions.<br>
+See [Create new Transaction with payment](/API/#-transaction-object) and [Create new Subscription](/API/#-subscription-object) for furhter information.
+</div>

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -12,6 +12,10 @@ A PayPal payment object represents the customer's PayPal account. When carrying 
 One client can have the same PayPal account attached to it multiple times. This is relevant when you create so-called *billing agreements* (see below), because you can have multiple different billing agreements with the same PayPal account.
 </div>
 
+<div class="important">
+Recurring payments use a special PayPal feature called “reference transactions”. Please contact PayPal and request that feature to be enabled for you.
+</div>
+
 ## Reusing a PayPal payment object
 
 You can normally use an existing payment object to create transactions and subscriptions. With PayPal, there is usually customer interaction involved.

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -48,6 +48,7 @@ curl https://api.paymill.com/v2.1/checksums \
 In addition to the mandatory payment details listed above, you can specify several other components of a payment:
 
 - **client_id:** Client (ID) where the created payment should belong to (optional).
+- **reusable_payment_description:** The Description appears at the checkout page (max. 127 characters).
 
 Please see our guide on [payments](/guides/reference/payments.html) for more details on payment setup.
 

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -49,7 +49,7 @@ In addition to the mandatory payment details listed above, you can specify sever
 
 - **client_id:** Client (ID) where the created payment should belong to (optional).
 
-Please see our guide on [transactions](/guides/reference/payments.html) for more details on payment setup.
+Please see our guide on [payments](/guides/reference/payments.html) for more details on payment setup.
 
 ## PayPal checkout
 

--- a/guides/paypal/payments.html.md
+++ b/guides/paypal/payments.html.md
@@ -87,11 +87,13 @@ https://www.example.com/shop/checkout/retry
 After PayPal checkout, the customer is redirected to your **return URL**. At this point, a payment has been created. The payment result is provided using the following URL parameters:
 
 - `paymill_payment_id`: PAYMILL payment ID, used to identify the payment in PAYMILL's system
-
+- `paymill_response_code`: Response code providing more details about the transaction status
+- `paymill_mode`: Indicates if the transaction was made in `live` or `test` mode.
+- 
 Here's an example URL called for a successful transaction:
 
 ```sh
-https://www.example.com/shop/checkout/result?paymill_payment_id=pay_2af32f858a47babeff78aeef
+https://www.example.com/shop/checkout/result?paymill_payment_id=pay_2af32f858a47babeff78aeef&paymill_response_code=20000&paymill_mode=test
 ```
 
 ### Retrieving payment details

--- a/guides/paypal/quick-start.html.md
+++ b/guides/paypal/quick-start.html.md
@@ -62,7 +62,7 @@ After creating a checksum, you can start a PayPal checkout session on your websi
 Now you can use our bridge to create a transaction, which will start a checkout session and send your customer to PayPal to confirm payment:
 
 ```javascript
-paymill.createTransaction({type: "paypal", checksum: "chk_2f82a672574647cd911d"});
+paymill.createTransaction({checksum: "chk_2f82a672574647cd911d"});
 ```
 
 <div class="info">

--- a/guides/paypal/subscriptions.html.md
+++ b/guides/paypal/subscriptions.html.md
@@ -8,20 +8,27 @@ menuOrder: 5
 
 Creating PayPal subscriptions through PAYMILL is easy:
 
-1. Follow the guide to [create a PayPal payment](/guides/paypal/payments.html).
-- Keep in mind to assign a client to the payment, as this is necessary for a valid subscription.
-- Now simply create a subscription like it is explained in the [subscription guide](/guides/reference/subscriptions).
+1. Create a payment object that can be used for recurring transactions.
+- Create a subscription based on that reusable payment object.
 
-## Payment setup
+## Creating a reusable PayPal means of payment
 
-After the payment was created like described in the [create a PayPal payment](/guides/paypal/payments.html) guide, no more interaction with the customer is necessary.
-All the following steps are done on your server, they don't differ from the steps of other payment methods like credit card or SEPA. PayPal can be handled the exact same way.
+A PayPal payment object represents the customer's PayPal account. In order for it to be reusable you have to obtain a so-called *billing agreement* from your customer. This allows you to charge future payments to their PayPal account and is indicated by `is_recurring=true` in the API response.
 
-<div class="info">
-Please refer to our [API reference](/API/#subscriptions) for more information on subscription details.
+You can create a reusable PayPal payment object during a regular PayPal transaction or you can just request a billing agreement without carrying out a transaction. See our [PayPal payment guide](/guides/paypal/payments.html) for more information.
+
+<div class="important">
+When creating the payment, make sure to assign it to the correct client as you will need to also assign the client to the subscription.
 </div>
 
-<div class="info">
-Keep in mind that you always need a connected PayPal account to be able to run PayPal subscriptions.
-If you disconnect your account from PayPal your subscriptions can't be charged any more.
+## Setting up a subscription based on PayPal
+
+Using an existing client and payment object, you can create a subscription either via our API or Merchant Centre.
+
+Simply follow the instructions in our [subscriptions guide](/guides/reference/subscriptions.html) to use the client and payment object to create a subscription.
+
+<div class="important">
+For PayPal subscriptions to run successfully, your PayPal account used to create them needs to be connected to PAYMILL.
+<strong>If you disconnect your PayPal account or connecting a different PayPal account, all pre-existing PayPal subscriptions will fail!</strong>
+Use the [subscription settings](https://app.paymill.com/settings/subscriptions) in our Merchant Centre to specify what should happen in these cases.
 </div>

--- a/guides/paypal/subscriptions.html.md
+++ b/guides/paypal/subscriptions.html.md
@@ -1,0 +1,27 @@
+---
+title: "PayPal Subscriptions"
+menu: "PayPal Subscriptions"
+type: "guide"
+status: "published"
+menuOrder: 5
+---
+
+Creating PayPal subscriptions through PAYMILL is easy:
+
+1. Follow the guide to [create a PayPal payment](/guides/paypal/payments.html).
+- Keep in mind to assign a client to the payment, as this is necessary for a valid subscription.
+- Now simply create a subscription like is explained in the [subscription guide](/guides/introduction/subscriptions).
+
+## Payment setup
+
+After the payment was created like described in the [create a PayPal payment](/guides/paypal/payments.html) guide, no more interaction with the customer is necessary.
+All the following steps are done on your server, they don't differ from the steps of other payment methods like credit card or SEPA, PayPal can be handled the exact same way.
+
+<div class="info">
+Please refer to our [API reference](/API/#subscriptions) for more information on subscription details.
+</div>
+
+<div class="info">
+Keep in mind that you always need a connected PayPal account to be able to run PayPal subscriptions.
+If you disconnect your account from PayPal your subscriptions can't be charged any more.
+</div>

--- a/guides/paypal/subscriptions.html.md
+++ b/guides/paypal/subscriptions.html.md
@@ -10,12 +10,12 @@ Creating PayPal subscriptions through PAYMILL is easy:
 
 1. Follow the guide to [create a PayPal payment](/guides/paypal/payments.html).
 - Keep in mind to assign a client to the payment, as this is necessary for a valid subscription.
-- Now simply create a subscription like is explained in the [subscription guide](/guides/introduction/subscriptions).
+- Now simply create a subscription like it is explained in the [subscription guide](/guides/introduction/subscriptions).
 
 ## Payment setup
 
 After the payment was created like described in the [create a PayPal payment](/guides/paypal/payments.html) guide, no more interaction with the customer is necessary.
-All the following steps are done on your server, they don't differ from the steps of other payment methods like credit card or SEPA, PayPal can be handled the exact same way.
+All the following steps are done on your server, they don't differ from the steps of other payment methods like credit card or SEPA. PayPal can be handled the exact same way.
 
 <div class="info">
 Please refer to our [API reference](/API/#subscriptions) for more information on subscription details.

--- a/guides/paypal/subscriptions.html.md
+++ b/guides/paypal/subscriptions.html.md
@@ -11,14 +11,18 @@ Creating PayPal subscriptions through PAYMILL is easy:
 1. Create a payment object that can be used for recurring transactions.
 - Create a subscription based on that reusable payment object.
 
+<div class="important">
+Recurring payments use a special PayPal feature called “reference transactions”. Please contact PayPal and request that feature to be enabled for you.
+</div>
+
 ## Creating a reusable PayPal means of payment
 
 A PayPal payment object represents the customer's PayPal account. In order for it to be reusable you have to obtain a so-called *billing agreement* from your customer. This allows you to charge future payments to their PayPal account and is indicated by `is_recurring=true` in the API response.
 
 You can create a reusable PayPal payment object during a regular PayPal transaction or you can just request a billing agreement without carrying out a transaction. See our [PayPal payment guide](/guides/paypal/payments.html) for more information.
 
-<div class="important">
-When creating the payment, make sure to assign it to the correct client as you will need to also assign the client to the subscription.
+<div class="info">
+When creating a subscription, you can explicitly link it to a client. Otherwise the owner of the payment will automatically be used.
 </div>
 
 ## Setting up a subscription based on PayPal

--- a/guides/paypal/subscriptions.html.md
+++ b/guides/paypal/subscriptions.html.md
@@ -10,7 +10,7 @@ Creating PayPal subscriptions through PAYMILL is easy:
 
 1. Follow the guide to [create a PayPal payment](/guides/paypal/payments.html).
 - Keep in mind to assign a client to the payment, as this is necessary for a valid subscription.
-- Now simply create a subscription like it is explained in the [subscription guide](/guides/introduction/subscriptions).
+- Now simply create a subscription like it is explained in the [subscription guide](/guides/reference/subscriptions).
 
 ## Payment setup
 

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -63,7 +63,9 @@ Please see our guide on [transactions](/guides/reference/transactions.html) for 
 
 <p class="important">If you specify a shopping cart, the <strong>item total must match the total transaction amount</strong>. If it doesn't, please use shipping and handling costs to specify the difference. If you don't specify a shopping cart, you also don't have to specify shipping or handling costs.</p>
 
-<p class="info">If the request with `request_reusable_payment=1` was successful, the payment attribute `is_recurring` will be `true`, which means you can reuse it for further transaction or for subscriptions.</p>
+<div class="info">If the request with `request_reusable_payment=1` was successful, the payment attribute `is_recurring` will be `true`, which means you can reuse it for further transactions or for subscriptions.<br>
+See [Create new Transaction with payment](/API/#-transaction-object) and [Create new Subscription](/API/#-subscription-object) for furhter information.
+</div>
 
 ## PayPal checkout
 

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -57,7 +57,7 @@ In addition to the mandatory transaction details listed above, you can specify s
 - **handling_costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
 - **client_id:** A new transaction will create a new payment. If you specify a client, the new payment will be attachted to it.
 - **request_reusable_payment:** Set this to `1` if you want to ask the buyer at the same time for a billing agreement. This means you can reuse the resulting payment to do further transactions without the need of asking the buyer again for permisson.
-- **reusable_payment_description:** The set description appears at the checkout page when you request permission for a resuable payment.
+- **reusable_payment_description:** The description appears at the checkout page when you request permission for a resuable payment (max. 127 characters).
 
 Please see our guide on [transactions](/guides/reference/transactions.html) for more details on transaction setup.
 
@@ -71,7 +71,7 @@ PayPal transactions are initiated on your website. The customer is redirected to
 
 1. Include the PAYMILL JavaScript bridge.
 - When button is clicked, use our JS bridge to start PayPal checkout.
-- Provide callback to handle any errors during transaction setup (e.g. invalid data)
+- Provide callback to handle any errors during transaction setup (e.g. invalid data).
 
 ```javascript
 paymill.createTransaction({

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -13,7 +13,7 @@ Accepting PayPal payments through PAYMILL is easy:
 - Pass the checksum ID to your website front-end and use our bridge to start PayPal checkout.
 - Handle the customer returning to your site along with information about the transaction result.
 
-## Transaction setup
+## Setting up a PayPal checkout
 
 Before you can start PayPal checkout from your website, you need to create a transaction checksum on your server using your private API key. This is to ensure the integrity of transaction data and to prevent your payment from being tampered with along the way.
 
@@ -56,14 +56,14 @@ In addition to the mandatory transaction details listed above, you can specify s
 - **Shipping costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
 - **Handling costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
 - **Client ID:** A new transaction will create a new payment. If you specify a client, the new payment will be attached to it.
-- **Require reusable payment:** This boolean option lets you ask the buyer for a billing agreement during checkout. If the buyer accepts, the resulting payment can be reused for transactions and subscriptions without additional interaction. See our guide on [payment objects](/guides/reference/payments.html) for further information.
+- **Require reusable payment:** This boolean option lets you ask the buyer for a billing agreement during checkout. If the buyer accepts, the resulting payment can be reused for transactions and subscriptions without additional interaction. See our guide on [PayPal payments](/guides/paypal/payments.html) for further information.
 - **Reusable payment description:** Optionally give a short description for why you need a billing agreement. This description appears in the checkout page as well as every subsequent transaction.
 
 Please see our guide on [transactions](/guides/reference/transactions.html) for more details on transaction setup.
 
 <p class="important">If you specify a shopping cart, the <strong>item total must match the total transaction amount</strong>. If it doesn't, please use shipping and handling costs to specify the difference. If you don't specify a shopping cart, you also don't have to specify shipping or handling costs.</p>
 
-## PayPal checkout
+## Starting a PayPal checkout
 
 PayPal transactions are initiated on your website. The customer is redirected to PayPal checkout and subsequently returned to your site where you can handle the result.
 
@@ -83,7 +83,7 @@ paymill.createTransaction({
 });
 ```
 
-## Cancelled transactions
+## Handling cancelled transactions
 
 When a customer cancels during PayPal checkout, they will be redirected to your **cancel URL**. This is a separate URL so you can offer your customers to review or modify their order and restart the checkout.
 
@@ -95,7 +95,7 @@ Here's an example URL called for a cancelled transaction:
 https://www.example.com/shop/checkout/retry
 ```
 
-## Transaction results
+## Handling transaction results
 
 After PayPal checkout, the customer is redirected to your **return URL**. At this point, a transaction has been created and is either successful, failed or pending. The transaction result is provided using the following URL parameters:
 

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -27,11 +27,11 @@ Please refer to our [API reference](/API) for more information on transaction de
 
 A PayPal transaction needs the checksum type to be specified as well as a valid transaction amount and currency. You also need to provide a valid cancel URL and return URL for the customer to return to.
 
-- **Checksum type:** Needs to be set to "PayPal" so that the checksum is later turned into a PayPal transaction.
-- **Amount:** Transaction amount as an integer, e.g. Euro cents. Must be the overall sum of all transaction components (see optional transaction details).
-- **Currency:** Valid currency code for this transaction. Will be used for all amounts within the transaction (see optional transaction details).
-- **Cancel URL:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
-- **Return URL:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
+- **checksum_type:** Needs to be set to "PayPal" so that the checksum is later turned into a PayPal transaction.
+- **amount:** Transaction amount as an integer, e.g. Euro cents. Must be the overall sum of all transaction components (see optional transaction details).
+- **currency:** Valid currency code for this transaction. Will be used for all amounts within the transaction (see optional transaction details).
+- **return_url:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
+- **cancel_url:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
 
 This example checksum contains all mandatory information for a PayPal transaction:
 
@@ -50,11 +50,12 @@ curl https://api.paymill.com/v2.1/checksums \
 
 In addition to the mandatory transaction details listed above, you can specify several other components of a transaction:
 
-- **Shipping address:** Shipping address for this transaction. Sent to PayPal where it's shown to the customer during checkout. PayPal also needs this for you to be eligible for seller protection.
-- **Billing address:** Billing address for this transaction. Not used by PayPal.
-- **Shopping cart:** List of items purchased in this transaction. Each item must have a name, amount and quantity. Additionally you can specify a description, item number (e.g. EAN/SKU) and the URL in your shop.
-- **Shipping costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
-- **Handling costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
+- **shipping_address:** Shipping address for this transaction. Sent to PayPal where it's shown to the customer during checkout. PayPal also needs this for you to be eligible for seller protection.
+- **billing_address:** Billing address for this transaction. Not used by PayPal.
+- **items:** List of items purchased in this transaction. Each item must have a name, amount and quantity. Additionally you can specify a description, item number (e.g. EAN/SKU) and the URL in your shop.
+- **shipping_costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
+- **handling_costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
+- **client_id:** A new transaction will create a new payment. If you specify a client, the new payment will be attachted to it.
 
 Please see our guide on [transactions](/guides/reference/transactions.html) for more details on transaction setup.
 

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -56,10 +56,14 @@ In addition to the mandatory transaction details listed above, you can specify s
 - **shipping_costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
 - **handling_costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
 - **client_id:** A new transaction will create a new payment. If you specify a client, the new payment will be attachted to it.
+- **request_reusable_payment:** Set this to `1` if you want to ask the buyer at the same time for a billing agreement. This means you can reuse the resulting payment to do further transactions without the need of asking the buyer again for permisson.
+- **reusable_payment_description:** The set description appears at the checkout page when you request permission for a resuable payment.
 
 Please see our guide on [transactions](/guides/reference/transactions.html) for more details on transaction setup.
 
 <p class="important">If you specify a shopping cart, the <strong>item total must match the total transaction amount</strong>. If it doesn't, please use shipping and handling costs to specify the difference. If you don't specify a shopping cart, you also don't have to specify shipping or handling costs.</p>
+
+<p class="info">If the request with `request_reusable_payment=1` was successful, the payment attribute `is_recurring` will be `true`, which means you can reuse it for further transaction or for subscriptions.</p>
 
 ## PayPal checkout
 

--- a/guides/paypal/transactions.html.md
+++ b/guides/paypal/transactions.html.md
@@ -27,11 +27,11 @@ Please refer to our [API reference](/API) for more information on transaction de
 
 A PayPal transaction needs the checksum type to be specified as well as a valid transaction amount and currency. You also need to provide a valid cancel URL and return URL for the customer to return to.
 
-- **checksum_type:** Needs to be set to "PayPal" so that the checksum is later turned into a PayPal transaction.
-- **amount:** Transaction amount as an integer, e.g. Euro cents. Must be the overall sum of all transaction components (see optional transaction details).
-- **currency:** Valid currency code for this transaction. Will be used for all amounts within the transaction (see optional transaction details).
-- **return_url:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
-- **cancel_url:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
+- **Checksum type:** Needs to be set to "PayPal" `paypal` so that the checksum is later turned into a PayPal transaction.
+- **Amount:** Transaction amount as an integer, e.g. Euro cents. Must be the overall sum of all transaction components (see optional transaction details).
+- **Currency:** Valid currency code for this transaction. Will be used for all amounts within the transaction (see optional transaction details).
+- **Return URL:** Used when your customer completed PayPal checkout and a transaction was created. The transaction outcome can be *successful*, *failed*, or *pending*. You will receive the transaction ID and status information as URL parameters.
+- **Cancel URL:** Used when your customer cancelled during PayPal checkout and returns to your store. At this URL, offer a way to review or modify the order and ask the customer to restart the checkout.
 
 This example checksum contains all mandatory information for a PayPal transaction:
 
@@ -50,22 +50,18 @@ curl https://api.paymill.com/v2.1/checksums \
 
 In addition to the mandatory transaction details listed above, you can specify several other components of a transaction:
 
-- **shipping_address:** Shipping address for this transaction. Sent to PayPal where it's shown to the customer during checkout. PayPal also needs this for you to be eligible for seller protection.
-- **billing_address:** Billing address for this transaction. Not used by PayPal.
-- **items:** List of items purchased in this transaction. Each item must have a name, amount and quantity. Additionally you can specify a description, item number (e.g. EAN/SKU) and the URL in your shop.
-- **shipping_costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
-- **handling_costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
-- **client_id:** A new transaction will create a new payment. If you specify a client, the new payment will be attachted to it.
-- **request_reusable_payment:** Set this to `1` if you want to ask the buyer at the same time for a billing agreement. This means you can reuse the resulting payment to do further transactions without the need of asking the buyer again for permisson.
-- **reusable_payment_description:** The description appears at the checkout page when you request permission for a resuable payment (max. 127 characters).
+- **Shippings address:** Shipping address for this transaction. Sent to PayPal where it's shown to the customer during checkout. PayPal also needs this for you to be eligible for seller protection.
+- **Billing address:** Billing address for this transaction. Not used by PayPal.
+- **Shopping cart:** List of items purchased in this transaction. Each item must have a name, amount and quantity. Additionally you can specify a description, item number (e.g. EAN/SKU) and the URL in your shop.
+- **Shipping costs:** Shipping costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
+- **Handling costs:** Handling costs included in the transaction amount. Only necessary if you provide a shopping cart and the item total doesn't match the transaction amount.
+- **Client ID:** A new transaction will create a new payment. If you specify a client, the new payment will be attached to it.
+- **Require reusable payment:** This boolean option lets you ask the buyer for a billing agreement during checkout. If the buyer accepts, the resulting payment can be reused for transactions and subscriptions without additional interaction. See our guide on [payment objects](/guides/reference/payments.html) for further information.
+- **Reusable payment description:** Optionally give a short description for why you need a billing agreement. This description appears in the checkout page as well as every subsequent transaction.
 
 Please see our guide on [transactions](/guides/reference/transactions.html) for more details on transaction setup.
 
 <p class="important">If you specify a shopping cart, the <strong>item total must match the total transaction amount</strong>. If it doesn't, please use shipping and handling costs to specify the difference. If you don't specify a shopping cart, you also don't have to specify shipping or handling costs.</p>
-
-<div class="info">If the request with `request_reusable_payment=1` was successful, the payment attribute `is_recurring` will be `true`, which means you can reuse it for further transactions or for subscriptions.<br>
-See [Create new Transaction with payment](/API/#-transaction-object) and [Create new Subscription](/API/#-subscription-object) for furhter information.
-</div>
 
 ## PayPal checkout
 

--- a/guides/reference/address-data.html.md
+++ b/guides/reference/address-data.html.md
@@ -3,7 +3,7 @@ title: "Address Data"
 menu: "Address Data"
 type: "guide"
 status: "published"
-menuOrder: 6
+menuOrder: 7
 ---
 
 You can attach two kinds of addresses to a transaction: a shipping address and a billing address. Both addresses have the following fields:

--- a/guides/reference/address-data.html.md
+++ b/guides/reference/address-data.html.md
@@ -3,7 +3,7 @@ title: "Address Data"
 menu: "Address Data"
 type: "guide"
 status: "published"
-menuOrder: 7
+menuOrder: 9
 ---
 
 You can attach two kinds of addresses to a transaction: a shipping address and a billing address. Both addresses have the following fields:

--- a/guides/reference/bridge-payframe-migration.html.md
+++ b/guides/reference/bridge-payframe-migration.html.md
@@ -3,7 +3,7 @@ title: "PayFrame Migration Guide"
 menu: "PayFrame Migration Guide"
 type: "guide"
 status: "published"
-menuOrder: 3
+menuOrder: 4
 ---
 
 In order to comply with PCI DSS 3.0 and be eligible for SAQ-A, you need to use our [Credit Card Frame](/guides/reference/bridge-payframe.html). If you were directly using our bridge before, this guide explains how you can easily switch to the new solution:

--- a/guides/reference/bridge-payframe.html.md
+++ b/guides/reference/bridge-payframe.html.md
@@ -3,7 +3,7 @@ title: "Bridge PayFrame"
 menu: "Bridge PayFrame"
 type: "guide"
 status: "published"
-menuOrder: 2
+menuOrder: 3
 ---
 
 PCI DSS 3.0 introduces a new set of requirements for merchants accepting credit card payments. In order to be (or stay) eligible for the simpler form of self assessment (SAQ A), we need to move all credit card data out of the scope of the merchant's website. We therefore offer an **iframe-based credit card form** that achieves SAQ A eligibility.

--- a/guides/reference/bridge.html.md
+++ b/guides/reference/bridge.html.md
@@ -3,7 +3,7 @@ title: "Bridge"
 menu: "Bridge"
 type: "guide"
 status: "published"
-menuOrder: 1
+menuOrder: 2
 ---
 
 How exactly does the PAYMILL bridge work and what are its features? These and similar questions are answered in this section.

--- a/guides/reference/clients.html.md
+++ b/guides/reference/clients.html.md
@@ -6,3 +6,30 @@ status: "published"
 menuOrder: 5
 ---
 
+A client represents your customer and links to all of their **means of payments** and **subscriptions**. Clients can be managed via our [API](/API/#clients) or the [clients](https://app.paymill.com/clients) section of our Merchant Centre.
+
+## Creating a client
+
+As a client is a very simple object, creating it only requires no specific details. You can add an **email address** or a **description** if applicable:
+
+```bash
+curl https://api.paymill.com/v2.1/clients \
+  -u "<YOUR_PRIVATE_KEY>:" \
+  -d "email=lovely-client@example.com" \
+  -d "description=Lovely Client"
+```
+
+<div class="info">
+You can access a client's `payment` and `subscription` list directly. To retrieve its payments, transactions, preauthorizations, or refunds, fetch the corresponding collection and use the client's `id` in the `client=<id>` filter parameter.
+</div>
+
+## Assigning a client to other resources
+
+When creating a resource, you usually have two choices: *Specify* the client explicitly or leave it out and have it either *assigned* or *created* automatically.
+
+Whether you create a payment, transaction, preauthorization or subscription, the rules are very simple: You can either derive it from an existing resource or create the new resource from scratch.
+
+When **creating a resource based on an existing resource**, e.g. transaction from payment or refund from transaction, you don't need to specify the client, it will be derived from the existing resource automatically.
+
+When **creating a new resource from scratch** without deriving it from an existing one, e.g. transaction from a token or checksum, you can optionally specify a client. When you don't specify one, it will be created automatically.
+ 

--- a/guides/reference/clients.html.md
+++ b/guides/reference/clients.html.md
@@ -1,0 +1,8 @@
+---
+title: "Clients"
+menu: "Clients"
+type: "guide"
+status: "published"
+menuOrder: 5
+---
+

--- a/guides/reference/data-export.html.md
+++ b/guides/reference/data-export.html.md
@@ -3,7 +3,7 @@ title: "Data Export to 3rd Party PSP"
 menu: "Data Export to 3rd Party PSP"
 type: "guide"
 status: "published"
-menuOrder: 10
+menuOrder: 12
 ---
 
 This document describes the process for a data export, which means transaction data shall be exported in a PCI compliant way and transferred to a third party system. The reason for a data export is the switch of a merchant using PAYMILL to another PSP.

--- a/guides/reference/data-export.html.md
+++ b/guides/reference/data-export.html.md
@@ -3,7 +3,7 @@ title: "Data Export to 3rd Party PSP"
 menu: "Data Export to 3rd Party PSP"
 type: "guide"
 status: "published"
-menuOrder: 9
+menuOrder: 10
 ---
 
 This document describes the process for a data export, which means transaction data shall be exported in a PCI compliant way and transferred to a third party system. The reason for a data export is the switch of a merchant using PAYMILL to another PSP.

--- a/guides/reference/data-migration.html.md
+++ b/guides/reference/data-migration.html.md
@@ -3,7 +3,7 @@ title: "Migration to PAYMILL Made Easy"
 menu: "Data Migration"
 type: "guide"
 status: "published"
-menuOrder: 9
+menuOrder: 11
 ---
 
 Our goal is enable you to migrate to PAYMILL as easy and fast as possible. Therefore we offer you a convenient and secure data transfer - for free.

--- a/guides/reference/data-migration.html.md
+++ b/guides/reference/data-migration.html.md
@@ -3,7 +3,7 @@ title: "Migration to PAYMILL Made Easy"
 menu: "Data Migration"
 type: "guide"
 status: "published"
-menuOrder: 8
+menuOrder: 9
 ---
 
 Our goal is enable you to migrate to PAYMILL as easy and fast as possible. Therefore we offer you a convenient and secure data transfer - for free.

--- a/guides/reference/payments.html.md
+++ b/guides/reference/payments.html.md
@@ -1,0 +1,7 @@
+---
+title: "Means of Payment"
+menu: "Means of Payment"
+type: "guide"
+status: "published"
+menuOrder: 6
+---

--- a/guides/reference/shopping-cart.html.md
+++ b/guides/reference/shopping-cart.html.md
@@ -3,7 +3,7 @@ title: "Shopping Cart Data"
 menu: "Shopping Cart Data"
 type: "guide"
 status: "published"
-menuOrder: 7
+menuOrder: 8
 ---
 
 ## Providing shopping cart items

--- a/guides/reference/shopping-cart.html.md
+++ b/guides/reference/shopping-cart.html.md
@@ -3,7 +3,7 @@ title: "Shopping Cart Data"
 menu: "Shopping Cart Data"
 type: "guide"
 status: "published"
-menuOrder: 8
+menuOrder: 10
 ---
 
 ## Providing shopping cart items

--- a/guides/reference/subscriptions.html.md
+++ b/guides/reference/subscriptions.html.md
@@ -3,7 +3,7 @@ title: "Subscriptions"
 menu: "Subscriptions"
 type: "guide"
 status: "published"
-menuOrder: 6
+menuOrder: 8
 ---
 
 ## 1. Setting up a Subscription

--- a/guides/reference/subscriptions.html.md
+++ b/guides/reference/subscriptions.html.md
@@ -3,7 +3,7 @@ title: "Subscriptions"
 menu: "Subscriptions"
 type: "guide"
 status: "published"
-menuOrder: 5
+menuOrder: 6
 ---
 
 ## 1. Setting up a Subscription

--- a/guides/reference/testing.html.md
+++ b/guides/reference/testing.html.md
@@ -3,7 +3,7 @@ title: "Testing"
 menu: "Testing"
 type: "guide"
 status: "published"
-menuOrder: 5
+menuOrder: 1
 ---
 
 ## 1. Which credit card information should you use for testing?

--- a/guides/reference/transactions.html.md
+++ b/guides/reference/transactions.html.md
@@ -3,7 +3,7 @@ title: "Transactions"
 menu: "Transactions"
 type: "guide"
 status: "published"
-menuOrder: 4
+menuOrder: 5
 ---
 
 In this document we want to show you some basic and advanced use cases with PAYMILL transactions. Please see our [API reference](/API) for more details on the capabilities of our transaction API.

--- a/guides/reference/transactions.html.md
+++ b/guides/reference/transactions.html.md
@@ -3,7 +3,7 @@ title: "Transactions"
 menu: "Transactions"
 type: "guide"
 status: "published"
-menuOrder: 5
+menuOrder: 7
 ---
 
 In this document we want to show you some basic and advanced use cases with PAYMILL transactions. Please see our [API reference](/API) for more details on the capabilities of our transaction API.

--- a/guides/reference/transactions.html.md
+++ b/guides/reference/transactions.html.md
@@ -48,7 +48,7 @@ paymill.createToken({
 
 In both cases your `callback` function will receive a token that you can then use in your server-side payment processing.
 
-<div class="important">
+<div class="info">
 Please see our [bridge reference](/guides/reference/bridge.html) for more information on direct tokenization.
 </div>
 
@@ -71,7 +71,7 @@ paymill.createTokenViaFrame({
 }, callback);
 ```
 
-<div class="important">
+<div class="info">
 Please see our [PayFrame guide](/guides/reference/bridge-payframe.html) for more information on how to use the embedded credit card form.
 </div>
 
@@ -88,7 +88,7 @@ curl https://api.paymill.com/v2.1/transactions \
   -d "description=Test Transaction"
 ```
 
-<div class="important">
+<div class="info">
 You use a token when using a credit card or direct debit account for the first time. For each subsequent transaction you will either have to create a new token since **tokens are not reusable** or you can use the payment object that has automatically been created with the first transaction.
 </div>
 
@@ -122,7 +122,7 @@ curl https://api.paymill.com/v2.1/transactions \
 ```
 
 <div class="important">
-Please note that **PayPal accounts are not reusable** at the moment since transactions require the customer to confirm payment.
+Please note that not all means of payment allow creating arbitrary transactions. For example, PayPal requires customer interaction unless you've obtained a billing agreement from your customer. Make sure to check the payment object's `is_recurring` flag and see our guide on [means of payment](/guides/reference/payments.html) for more information.
 </div>
 
 ### Creating a transaction from a preauthorization
@@ -159,7 +159,7 @@ curl https://api.paymill.com/v2.1/transactions \
 
 ### Specifying an app fee
 
-If you use **PAYMILL Unite**, e.g. for a marketplace application, you can add fees to the transactions of your merchants. Create a transaction as usual and add the fee you want to charge as well as the payment object that should be used to settle that fee:
+If you use **PAYMILL Connect**, e.g. for a marketplace application, you can add fees to the transactions of your merchants. Create a transaction as usual and add the fee you want to charge as well as the payment object that should be used to settle that fee:
 
 ```sh
 curl https://api.paymill.com/v2.1/transactions \


### PR DESCRIPTION
**PAYMILL now supports recurring payments for PayPal!**

Payment instrument representing PayPal accounts can now be reusable. If this is the case, subsequent transactions can be created for this account, either by a subscription or manually.

For a PayPal payment instrument to be usable for recurring payments, the merchant needs to obtain a billing agreement from the customer. This can be done either while doing a transaction or completely stand-alone by preparing a different kind of checkout that only generates a payment instrument.

Once a payment instrument is usable for recurring transactions (indicated by `is_recurring=true`), you can create subscriptions based on this payment instrument. You can also create transactions manually, we called this “unattended payments” because contrary to regular PayPal transactions there’s no user interaction involved.

All of this is documented in new guides on PayPal _subscriptions_ and _payments_, we also created general guides on _subscriptions_, _payments_ and _clients_.
